### PR TITLE
Feature/docker compose for hosting in windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ docker-compose up       # Setup and run both the MySQL server and Servatrice.
 
 >Note: The first time running the docker-compose setup, the MySQL server will take a little time to run the initial setup scripts. Due to this, the Servatrice instance may fail the first few attempts to connect to the database. Servatrice is set to `restart: always` in the docker-compose.yml, which will allow it to continue attempting to start up. Once the MySQL scripts have completed, Servatrice should then connect automatically on the next attempt.
 
+**Docker compose in Windows**
+A out of box working docker-compose file has been added to help setup in Windows.
+
+Docker in Windows requires additional steps in form of using Docker Desktop to allow resource sharing from the drive the volumes are mapped from, as well as potential workarounds needed to get file sharing working in Windows. This [StackOverflow discussion sheds some light on it](https://stackoverflow.com/questions/42203488/settings-to-windows-firewall-to-allow-docker-for-windows-to-share-drive)
+
 # License [![GPLv2 License](https://img.shields.io/github/license/Cockatrice/Cockatrice.svg)](https://github.com/Cockatrice/Cockatrice/blob/master/LICENSE)
 
 Cockatrice is free software, licensed under the [GPLv2](https://github.com/Cockatrice/Cockatrice/blob/master/LICENSE).

--- a/docker-compose.yml.windows
+++ b/docker-compose.yml.windows
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=root-password
+      - MYSQL_DATABASE=servatrice
+      - MYSQL_USER=servatrice
+      - MYSQL_PASSWORD=password
+    volumes:
+      - ./servatrice/servatrice.sql:/docker-entrypoint-initdb.d/servatrice.sql
+      - ./servatrice/mysql-storage:/var/lib/mysql
+
+  servatrice:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: servatrice
+    depends_on:
+      - mysql
+    ports:
+      - "4747:4747"
+      - "4748:4748"
+    entrypoint: "/bin/bash -c 'sleep 10; servatrice --config /tmp/servatrice.ini --log-to-console'"
+    restart: always
+    volumes:
+      - ./servatrice/docker/servatrice-docker.ini:/tmp/servatrice.ini

--- a/servatrice/mysql-storage/.gitignore
+++ b/servatrice/mysql-storage/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
## Short roundup of the initial problem
Setting up docker to work in Windows was troublesome. Proved out, that docker-compose provides a easier way.

## What will change with this Pull Request?
- An docker-compose file is supplied that will work with Windows.
- An example location configured for mysql database on host machine.